### PR TITLE
Reject legacy `comp_clr` inputs for Aitchison distance and bump to 0.13.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: microViz
 Title: Microbiome Data Analysis and Visualization
-Version: 0.13.0
+Version: 0.13.1
 Authors@R: 
     person(given = "David",
            family = "Barnett",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# microViz 0.13.1
+
+### Fix:
+
+- `dist_calc(dist = "aitchison")` now correctly errors when input data were transformed with legacy `tax_transform("comp_clr")`, preventing invalid double-CLR processing.
+
 # microViz 0.13.0
 
 ### Breaking changes: 

--- a/R/dist_calc.R
+++ b/R/dist_calc.R
@@ -124,7 +124,8 @@ dist_calc <- function(data,
 # (psExtra `info` required for transformation check)
 #
 distMatAitchison <- function(ps, dist, info) {
-  if (identical(info$tax_trans, "clr") || identical(info$tax_trans, "rclr")) {
+  tax_transforms <- unlist(strsplit(info$tax_trans, split = "&", fixed = TRUE))
+  if (any(tax_transforms %in% c("clr", "rclr", "comp_clr"))) {
     rlang::abort(call = rlang::caller_env(1), message = c(
       "dist_calc 'aitchison' distance requires count data",
       i = paste0(

--- a/tests/testthat/test-dist_calc.R
+++ b/tests/testthat/test-dist_calc.R
@@ -95,5 +95,13 @@ test_that("dist_calc throws errors", {
     regexp = "dist_calc 'aitchison' distance requires count data"
   )
 
+  expect_error(
+    object = dist_calc(
+      data = tax_transform(microViz::ibd, trans = "comp_clr"),
+      dist = "aitchison"
+    ),
+    regexp = "dist_calc 'aitchison' distance requires count data"
+  )
+
   expect_error(dist_calc(data = 2), regexp = "data is class: numeric")
 })


### PR DESCRIPTION
### Motivation

- Prevent invalid double-CLR processing by making `dist_calc(dist = "aitchison")` error when input data were already transformed with CLR-like transforms including the legacy `comp_clr` option.
- Bump package version and document the fix in the release notes.

### Description

- Update `distMatAitchison` in `R/dist_calc.R` to parse `info$tax_trans` (split on `"&"`) and treat `"comp_clr"` the same as `"clr"`/`"rclr"`, aborting with a clear error when such transforms are present.
- Keep the existing transformation-to-distance mapping for `"aitchison"` -> `"clr"` and `"robust.aitchison"` -> `"rclr"` and compute distances via `microbiome::abundances` followed by `stats::dist`.
- Bump package version from `0.13.0` to `0.13.1` in `DESCRIPTION` and add a short note to `NEWS.md` about the fix.
- Add a unit test in `tests/testthat/test-dist_calc.R` asserting that `dist_calc` errors when input is transformed with `tax_transform(..., trans = "comp_clr")`.

### Testing

- Ran package unit tests with `testthat` containing the updated `test-dist_calc.R` spec, and all tests passed including the new `comp_clr` error expectation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1af0815c0832a9d334bc6bae8cae2)